### PR TITLE
chore(deps): bump @wowserhq/io from 1.2.2 to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@wowserhq/io": "^1.2.2"
+        "@wowserhq/io": "^1.3.0"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^18.4.3",
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@wowserhq/io": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.2.2.tgz",
-      "integrity": "sha512-5M9KIm5Tv65xukPe45AnSqQdmwY0iM1YYZyb6kvLIHG/Y80cVOqOYJLnRN4/QGqHst03IIy6PUGKHIA7TdlBaw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.3.0.tgz",
+      "integrity": "sha512-JBNwIpmIKlOV5TQUWEGDOy0k5KvcNn2LmdVdnNvihPOzdjcIh28FKzCeg4HsSr7dRaxJeABlCh4fn2LKmohKaQ=="
     },
     "node_modules/acorn": {
       "version": "8.11.2",
@@ -6787,9 +6787,9 @@
       }
     },
     "@wowserhq/io": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.2.2.tgz",
-      "integrity": "sha512-5M9KIm5Tv65xukPe45AnSqQdmwY0iM1YYZyb6kvLIHG/Y80cVOqOYJLnRN4/QGqHst03IIy6PUGKHIA7TdlBaw=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.3.0.tgz",
+      "integrity": "sha512-JBNwIpmIKlOV5TQUWEGDOy0k5KvcNn2LmdVdnNvihPOzdjcIh28FKzCeg4HsSr7dRaxJeABlCh4fn2LKmohKaQ=="
     },
     "acorn": {
       "version": "8.11.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "wowser"
   ],
   "dependencies": {
-    "@wowserhq/io": "^1.2.2"
+    "@wowserhq/io": "^1.3.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18.4.3",

--- a/src/lib/blp/Blp.ts
+++ b/src/lib/blp/Blp.ts
@@ -25,7 +25,7 @@ class Blp {
 
   load(source: IoSource) {
     const stream = openStream(source);
-    const header = blpIo.header.read(stream, {});
+    const header = blpIo.header.read(stream);
 
     if (header.magic !== BLP_MAGIC) {
       stream.close();

--- a/src/lib/blp/io.ts
+++ b/src/lib/blp/io.ts
@@ -2,21 +2,18 @@ import * as io from '@wowserhq/io';
 import { MAX_MIPS } from './const.js';
 import { IoType } from '@wowserhq/io';
 
-const header: IoType = io.struct(
-  {
-    magic: io.string({ size: 4, terminate: false }),
-    formatVersion: io.uint32le,
-    colorFormat: io.uint8,
-    alphaSize: io.uint8,
-    preferredFormat: io.uint8,
-    hasMips: io.uint8,
-    width: io.uint32le,
-    height: io.uint32le,
-    mipOffsets: io.array(io.uint32le, { size: MAX_MIPS }),
-    mipSizes: io.array(io.uint32le, { size: MAX_MIPS }),
-    extended: io.array(io.uint8, { size: 1024 }),
-  },
-  {},
-);
+const header: IoType = io.struct({
+  magic: io.string({ size: 4, terminate: false }),
+  formatVersion: io.uint32le,
+  colorFormat: io.uint8,
+  alphaSize: io.uint8,
+  preferredFormat: io.uint8,
+  hasMips: io.uint8,
+  width: io.uint32le,
+  height: io.uint32le,
+  mipOffsets: io.array(io.uint32le, { size: MAX_MIPS }),
+  mipSizes: io.array(io.uint32le, { size: MAX_MIPS }),
+  extended: io.array(io.uint8, { size: 1024 }),
+});
 
 export { header };


### PR DESCRIPTION
`@wowserhq/io` `1.3.0` cleans up a few type definitions, permitting us to drop a couple pointless defaults.