### PR TITLE
feat(blp): add supporting for saving BLPs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@wowserhq/io": "^1.3.0"
+        "@wowserhq/io": "^1.4.0"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^18.4.3",
@@ -1855,9 +1855,9 @@
       }
     },
     "node_modules/@wowserhq/io": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.3.0.tgz",
-      "integrity": "sha512-JBNwIpmIKlOV5TQUWEGDOy0k5KvcNn2LmdVdnNvihPOzdjcIh28FKzCeg4HsSr7dRaxJeABlCh4fn2LKmohKaQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.4.0.tgz",
+      "integrity": "sha512-j1ovYSdpi2z1SbDF3OMc5ueo5LL37cjISreYlLn2T5n1QBowZwmW35kXw1E/FUJyvQ1+tf/GxTH9j9hZp7hWWA=="
     },
     "node_modules/acorn": {
       "version": "8.11.2",
@@ -6836,9 +6836,9 @@
       }
     },
     "@wowserhq/io": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.3.0.tgz",
-      "integrity": "sha512-JBNwIpmIKlOV5TQUWEGDOy0k5KvcNn2LmdVdnNvihPOzdjcIh28FKzCeg4HsSr7dRaxJeABlCh4fn2LKmohKaQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wowserhq/io/-/io-1.4.0.tgz",
+      "integrity": "sha512-j1ovYSdpi2z1SbDF3OMc5ueo5LL37cjISreYlLn2T5n1QBowZwmW35kXw1E/FUJyvQ1+tf/GxTH9j9hZp7hWWA=="
     },
     "acorn": {
       "version": "8.11.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "wowser"
   ],
   "dependencies": {
-    "@wowserhq/io": "^1.3.0"
+    "@wowserhq/io": "^1.4.0"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^18.4.3",

--- a/src/spec/blp/Blp.spec.ts
+++ b/src/spec/blp/Blp.spec.ts
@@ -1,5 +1,6 @@
 import Blp, { BLP_COLOR_FORMAT, BLP_IMAGE_FORMAT } from '../../lib/blp/Blp.js';
 import { describe, expect, test } from 'vitest';
+import * as fs from 'fs';
 
 describe('Blp', () => {
   describe('load', () => {
@@ -395,6 +396,68 @@ describe('Blp', () => {
         const lastPixel = image.data.subarray(262140, 262144);
         expect(lastPixel).toStrictEqual(new Uint8Array([0, 0, 0, 0]));
       });
+    });
+  });
+
+  describe('save', () => {
+    test('should save empty blp', () => {
+      const blp = new Blp();
+      const data = blp.save();
+
+      const loadedBlp = new Blp();
+      loadedBlp.load(data);
+
+      expect(loadedBlp.magic).toBe('BLP2');
+      expect(loadedBlp.formatVersion).toBe(1);
+      expect(loadedBlp.colorFormat).toBe(BLP_COLOR_FORMAT.COLOR_DXT);
+      expect(loadedBlp.width).toBe(0);
+      expect(loadedBlp.height).toBe(0);
+      expect(loadedBlp.alphaSize).toBe(0);
+    });
+
+    test('should save raw blp', () => {
+      const blp = new Blp();
+      blp.load('./fixture/raw.blp');
+      const savedData = blp.save();
+
+      const originalBuffer = fs.readFileSync('./fixture/raw.blp');
+      const originalData = new Uint8Array(originalBuffer.buffer);
+
+      // header
+      expect(savedData.subarray(0, 1172)).toEqual(originalData.subarray(0, 1172));
+
+      // mips
+      expect(savedData.subarray(1172)).toEqual(originalData.subarray(1172));
+    });
+
+    test('should save dxt blp', () => {
+      const blp = new Blp();
+      blp.load('./fixture/dxt3.blp');
+      const savedData = blp.save();
+
+      const originalBuffer = fs.readFileSync('./fixture/dxt3.blp');
+      const originalData = new Uint8Array(originalBuffer.buffer);
+
+      // header
+      expect(savedData.subarray(0, 1172)).toEqual(originalData.subarray(0, 1172));
+
+      // mips
+      expect(savedData.subarray(1172)).toEqual(originalData.subarray(1172));
+    });
+
+    test('should save pal blp', () => {
+      const blp = new Blp();
+      blp.load('./fixture/pala4.blp');
+      const savedData = blp.save();
+
+      const originalBuffer = fs.readFileSync('./fixture/pala4.blp');
+      const originalData = new Uint8Array(originalBuffer.buffer);
+
+      // header
+      expect(savedData.subarray(0, 1172)).toEqual(originalData.subarray(0, 1172));
+
+      // mips
+      expect(savedData.subarray(1172)).toEqual(originalData.subarray(1172));
     });
   });
 });


### PR DESCRIPTION
This PR introduces initial support for saving BLPs. An upcoming PR will land an implementation of `setImage`, permitting the creation of BLPs from scratch with arbitrary image data.