### PR TITLE
feat(blp): add support for setting images with raw color format

### DIFF
--- a/src/lib/blp/raw.ts
+++ b/src/lib/blp/raw.ts
@@ -13,4 +13,6 @@ const rawArgb8888ToAbgr8888 = (width: number, height: number, input: Uint8Array)
   return output;
 };
 
-export { rawArgb8888ToAbgr8888 };
+const rawAbgr8888ToArgb8888 = rawArgb8888ToAbgr8888;
+
+export { rawArgb8888ToAbgr8888, rawAbgr8888ToArgb8888 };

--- a/src/lib/blp/util.ts
+++ b/src/lib/blp/util.ts
@@ -1,4 +1,4 @@
-const calcLevelCount = (width, height) => {
+const calcLevelCount = (width: number, height: number) => {
   let count = 1;
 
   let w = width === height * 6 ? width / 6 : width;
@@ -15,4 +15,52 @@ const calcLevelCount = (width, height) => {
 
 const getSizeAtMipLevel = (size: number, level: number) => (size / (1 << level)) | 0;
 
-export { calcLevelCount, getSizeAtMipLevel };
+const resizeBilinear = (
+  data: Uint8Array,
+  width: number,
+  height: number,
+  newWidth: number,
+  newHeight: number,
+): Uint8Array => {
+  const newData = new Uint8Array(newWidth * newHeight * 4);
+
+  for (let y = 0; y < newHeight; y++) {
+    for (let x = 0; x < newWidth; x++) {
+      const targetIndex = (y * newWidth + x) * 4;
+
+      // Calculate corresponding coordinates in the original image
+      const sourceX = (x * (width - 1)) / (newWidth - 1);
+      const sourceY = (y * (height - 1)) / (newHeight - 1);
+
+      // Get the four surrounding pixels in the original image
+      const xFloor = Math.floor(sourceX);
+      const yFloor = Math.floor(sourceY);
+      const xCeil = Math.ceil(sourceX);
+      const yCeil = Math.ceil(sourceY);
+
+      // Bilinear interpolation weights
+      const xWeight = sourceX - xFloor;
+      const yWeight = sourceY - yFloor;
+
+      // Interpolate each color channel separately
+      for (let i = 0; i < 4; i++) {
+        const topLeft = data[(yFloor * width + xFloor) * 4 + i];
+        const topRight = data[(yFloor * width + xCeil) * 4 + i];
+        const bottomLeft = data[(yCeil * width + xFloor) * 4 + i];
+        const bottomRight = data[(yCeil * width + xCeil) * 4 + i];
+
+        // Bilinear interpolation formula
+        const topInterpolation = topLeft + xWeight * (topRight - topLeft);
+        const bottomInterpolation = bottomLeft + xWeight * (bottomRight - bottomLeft);
+        const finalInterpolation =
+          topInterpolation + yWeight * (bottomInterpolation - topInterpolation);
+
+        newData[targetIndex + i] = finalInterpolation;
+      }
+    }
+  }
+
+  return newData;
+};
+
+export { calcLevelCount, getSizeAtMipLevel, resizeBilinear };

--- a/src/spec/blp/Blp.spec.ts
+++ b/src/spec/blp/Blp.spec.ts
@@ -460,4 +460,84 @@ describe('Blp', () => {
       expect(savedData.subarray(1172)).toEqual(originalData.subarray(1172));
     });
   });
+
+  describe('setImage', () => {
+    describe('raw', () => {
+      test('should set image with given ARGB8888 source and mipmap generation disabled', () => {
+        const srcBlp = new Blp();
+        srcBlp.load('./fixture/raw.blp');
+        const srcImage = srcBlp.getImage(0, BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+
+        const dstBlp = new Blp();
+        dstBlp.colorFormat = BLP_COLOR_FORMAT.COLOR_RAW;
+        dstBlp.setImage(srcImage, false);
+        const dstImage = dstBlp.getImage(0);
+
+        expect(dstBlp.width).toBe(256);
+        expect(dstBlp.height).toBe(256);
+        expect(dstBlp.colorFormat).toBe(BLP_COLOR_FORMAT.COLOR_RAW);
+
+        expect(dstImage.width).toBe(256);
+        expect(dstImage.height).toBe(256);
+        expect(dstImage.format).toBe(BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+      });
+
+      test('should set image with given ARGB8888 source and mipmap generation enabled', () => {
+        const srcBlp = new Blp();
+        srcBlp.load('./fixture/raw.blp');
+        const srcImage = srcBlp.getImage(0, BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+
+        const dstBlp = new Blp();
+        dstBlp.colorFormat = BLP_COLOR_FORMAT.COLOR_RAW;
+        dstBlp.setImage(srcImage, true);
+        const dstImage = dstBlp.getImage(1);
+
+        expect(dstBlp.width).toBe(256);
+        expect(dstBlp.height).toBe(256);
+        expect(dstBlp.colorFormat).toBe(BLP_COLOR_FORMAT.COLOR_RAW);
+
+        expect(dstImage.width).toBe(128);
+        expect(dstImage.height).toBe(128);
+        expect(dstImage.format).toBe(BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+      });
+
+      test('should set image with given ABGR8888 source and mipmap generation disabled', () => {
+        const srcBlp = new Blp();
+        srcBlp.load('./fixture/raw.blp');
+        const srcImage = srcBlp.getImage(0, BLP_IMAGE_FORMAT.IMAGE_ABGR8888);
+
+        const dstBlp = new Blp();
+        dstBlp.colorFormat = BLP_COLOR_FORMAT.COLOR_RAW;
+        dstBlp.setImage(srcImage, false);
+        const dstImage = dstBlp.getImage(0);
+
+        expect(dstBlp.width).toBe(256);
+        expect(dstBlp.height).toBe(256);
+        expect(dstBlp.colorFormat).toBe(BLP_COLOR_FORMAT.COLOR_RAW);
+
+        expect(dstImage.width).toBe(256);
+        expect(dstImage.height).toBe(256);
+        expect(dstImage.format).toBe(BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+      });
+
+      test('should set image with given ABGR8888 source and mipmap generation enabled', () => {
+        const srcBlp = new Blp();
+        srcBlp.load('./fixture/raw.blp');
+        const srcImage = srcBlp.getImage(0, BLP_IMAGE_FORMAT.IMAGE_ABGR8888);
+
+        const dstBlp = new Blp();
+        dstBlp.colorFormat = BLP_COLOR_FORMAT.COLOR_RAW;
+        dstBlp.setImage(srcImage, true);
+        const dstImage = dstBlp.getImage(1);
+
+        expect(dstBlp.width).toBe(256);
+        expect(dstBlp.height).toBe(256);
+        expect(dstBlp.colorFormat).toBe(BLP_COLOR_FORMAT.COLOR_RAW);
+
+        expect(dstImage.width).toBe(128);
+        expect(dstImage.height).toBe(128);
+        expect(dstImage.format).toBe(BLP_IMAGE_FORMAT.IMAGE_ARGB8888);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR introduces the ability to set images in BLPs using `COLOR_FORMAT_RAW.` Supported image formats are `IMAGE_ABGR8888` and `IMAGE_ARGB8888`.